### PR TITLE
Festival workaround

### DIFF
--- a/NanoPi Code/Firmware/README.md
+++ b/NanoPi Code/Firmware/README.md
@@ -31,7 +31,7 @@ value the code returns.
 |Row 1|1: `0`|2: `1`|3: `2`|A: `3`|
 |Row 2|4: `4`|5: `5`|6: `6`|B: `7`|
 |Row 3|7: `8`|8: `9`|9: `10`|C: `11`|
-|Row 4|*: `12`|0: `13`|#: `14`|D: `14`|
+|Row 4|*: `12`|0: `13`|#: `14`|D: `15`|
 
 A properly formatted packet will conatin a lowercase `r` in the data field. More data could follow but the keypad code only cares about the first character in the data field. Subsequent data after the first charater are ignored.
 

--- a/NanoPi Code/Firmware/audio_firmware.c
+++ b/NanoPi Code/Firmware/audio_firmware.c
@@ -75,10 +75,21 @@ void audio_process() {
         char* remaining_string = requested_string + 1;
         int system_result;
         unsigned short packet_tag = received_packet->tag;
-        if(audio_type_byte == 's') {
-            AUDIO_PRINTF("Festival tts %s\n", remaining_string);
-            sprintf(buffer, "echo '%s' | festival --tts", remaining_string);
+        if(audio_type_byte == 'd') {
+            AUDIO_PRINTF("Festival tts without saving file");
+            system("cd /tmp");
+            sprintf(buffer, "echo '%s' | text2wave -o output.wav", remaining_string);
             system_result = system(buffer);
+            system_result = system("aplay output.wav");
+            system("cd -");
+        } if(audio_type_byte == 's') {
+            AUDIO_PRINTF("Festival tts %s with saving file\n", remaining_string);
+            system("cd ../Firmware/pregen_audio");
+            sprintf(buffer, "echo '%s' | text2wave -o %s.wav", remaining_string, remaining_string);
+            system_result = system(buffer);
+            sprintf(buffer, "aplay %s.wav", remaining_string);
+            system(buffer);
+            system("cd -");
         } else if(audio_type_byte == 'p') {
             strcpy(buffer, "aplay ");
             strcat(remaining_string, ".wav");


### PR DESCRIPTION
This fixes the audio issue where Festival refuses to use audio correctly. This instead generates tts into an audio file and then plays it back. It can be either saved or discarded in the `/tmp` directory.